### PR TITLE
Smaller instance size

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,6 @@
 applications:
  - name: dizzylizard
    buildpack: nodejs_buildpack
-   memory: 512M
-   disk_quota: 768M
+   memory: 32M
+   disk_quota: 128M
    instances: 4


### PR DESCRIPTION
This app really doesn't need this much memory and disk. Changing to smaller defaults would let you demonstrate horizontal scaling on smaller quotas / cf endpoints.